### PR TITLE
fix: The following assembly name can not be resolved automatically

### DIFF
--- a/CadAddinManager/Model/AssemLoader.cs
+++ b/CadAddinManager/Model/AssemLoader.cs
@@ -80,7 +80,7 @@ public class AssemLoader
         else stringBuilder.Append("-Executing-");
         tempFolder = FileUtils.CreateTempFolder(stringBuilder.ToString());
         string fileAssemblyTemp = ResolveDuplicateMethod(originalFilePath);
-        var assembly = CopyAndLoadAddin(fileAssemblyTemp, parsingOnly);
+        var assembly = CopyAndLoadAddin(originalFilePath, parsingOnly);
         if (assembly == null || !IsAPIReferenced(assembly))
         {
             return null;


### PR DESCRIPTION
### Purpose

(FILL ME IN) for fix this issue:  "The following assembly name can not be resolved automatically..."

## Trouble
When the `CopyAndLoadAddin` method is executed, the fileAssemblyTemp variable value is a temporary path, Only one file was copied

here should copy the original path and put all the dll files into the temporary directory so that the relevant `.dll` files can be found