### PR TITLE
Fix bugs

### DIFF
--- a/CadAddinManager/Model/AssemLoader.cs
+++ b/CadAddinManager/Model/AssemLoader.cs
@@ -80,7 +80,8 @@ public class AssemLoader
         else stringBuilder.Append("-Executing-");
         tempFolder = FileUtils.CreateTempFolder(stringBuilder.ToString());
         string fileAssemblyTemp = ResolveDuplicateMethod(originalFilePath);
-        var assembly = CopyAndLoadAddin(fileAssemblyTemp, parsingOnly);
+		refedFolders.Add(Path.GetDirectoryName(originalFilePath));
+		var assembly = CopyAndLoadAddin(fileAssemblyTemp, parsingOnly);
         if (assembly == null || !IsAPIReferenced(assembly))
         {
             return null;
@@ -134,7 +135,7 @@ public class AssemLoader
         }
         string fileAssemblyTemp = SaveAssemblyModifyToTemp(originalFilePath);
         ass.Write(fileAssemblyTemp);
-        return fileAssemblyTemp;
+		return fileAssemblyTemp;
     }
     public static AssemblyDefinition GetAssemblyDef(string assemblyPath)
     {

--- a/CadAddinManager/Model/AssemLoader.cs
+++ b/CadAddinManager/Model/AssemLoader.cs
@@ -134,7 +134,7 @@ public class AssemLoader
             }
         }
         string fileAssemblyTemp = SaveAssemblyModifyToTemp(originalFilePath);
-        ass.Write(fileAssemblyTemp);
+		ass.Write(fileAssemblyTemp, new WriterParameters() { WriteSymbols = true });
 		return fileAssemblyTemp;
     }
     public static AssemblyDefinition GetAssemblyDef(string assemblyPath)


### PR DESCRIPTION
Hi, there are two fixes.
1. Added the path of the directory that the user selects when loading the dll. Now the resolver will find dependent assemblies.
2. Used an overload of the AssemblyDefinition. Write method with options, where I specified that it was necessary to generate a pdb file. Without them, visual studio could not connect to the executable library.

### Declarations

Check these if you believe they are true

- [ +] This PR fix bug

@chuongmep 